### PR TITLE
RESTClient / Lazy get environ variables and multiple accounts

### DIFF
--- a/src/SnowLibrary/__init__.py
+++ b/src/SnowLibrary/__init__.py
@@ -1,4 +1,4 @@
-from .keywords import RESTQuery, RESTInsert
+from .keywords import RESTQuery, RESTInsert, RESTClient
 from .keywords import DataFile
 from .keywords import NotificationHelper
 

--- a/src/SnowLibrary/keywords/__init__.py
+++ b/src/SnowLibrary/keywords/__init__.py
@@ -1,3 +1,4 @@
+from .rest_api import RESTClient
 from .rest_api import RESTQuery
 from .rest_api import RESTInsert
 from .file_creator import DataFile


### PR DESCRIPTION
resolve variables from environnement only when needed, not at start.
This way, it is not mandatory to execute RobotFramework with environ variables set.

*** Settings ***
Resource          variables.robot

*** Keywords ***
test lazy
    Set Environment Variable  SNOW_TEST_URL  host_or_url
    Set Environment Variable  SNOW_REST_USER  l0g1n
    Set Environment Variable  SNOW_REST_PASS  p4ssw0rd
    # will re-get environ variables
    Snow Reset Client
    Get Snow Instance
    Query Table Is  sc_req_item
    Required Query Parameter Is     number        EQUALS  SRV123
    Execute Query

